### PR TITLE
Editing `commands.md`

### DIFF
--- a/docs/rocksmarker/commands.md
+++ b/docs/rocksmarker/commands.md
@@ -10,47 +10,47 @@ tags:
 
 ## Introduction
 
-Neovim offers a wide range of features to customize and automate your workflow. Among these, autocmds (short for “auto-commands”) are one of the most powerful and versatile features. In this chapter, we will explore the features provided by Rocksmarker's autocmds and how they are used to improve productivity and the editor experience.
+Neovim offers a wide range of features to customize and automate your workflow. Among these, autocmds (short for “auto-commands”) are one of the most powerful and versatile features. In this chapter, we will explore the features provided by Rocksmarker's autocmds and how to use them to improve productivity and the editor experience.
 
-### What is an Autocmd?
+### What is an autocmd
 
-An autocmd is a command that is executed automatically when a certain event occurs within Neovim. Events can range from actions such as opening a file, editing a buffer, closing a window, to more specific events such as inserting a character or pressing a key.
+An autocmd is a command that runs automatically when a certain event occurs within Neovim. Events can range from actions such as opening a file, editing a buffer, closing a window, to more specific events such as inserting a character or pressing a key.
 
 ### Autocmds functionality
 
-Autocmds in Neovim offer a range of features that can be used to customize and automate your workflow. Some of the most important features include:
+Autocmds in Neovim offer a range of features that you can use to customize and automate your workflow. Some of the most important features include:
 
 : **Automatic execution of commands**
 
-: Autocmds can be used to execute commands automatically when a specific event occurs.
+: Autocmds can run commands automatically when a specific event occurs.
 
 : **Interface customization**
 
-: Autocmds can be used to customize the Neovim interface, for example by changing the buffer display, window settings, etc.
+: Autocmds can provide customization to the Neovim interface, for example by changing the buffer display, window settings, and so on.
 
 : **File and buffer management**
 
-: Autocmds can be used to manage files and buffers, for example by automatically loading a file when a buffer is opened, or saving a file when a buffer is closed.
+: Autocmds can manage files and buffers. An example would be automatically loading a file when you open a buffer, or saving a file when you close a buffer.
 
 : **Integration with other tools**
 
-: Autocmds can be used to integrate Neovim with other tools and applications, for example by executing external commands or interacting with other editors.
+: Autocmds can integrate Neovim with other tools and applications, for example by executing external commands or interacting with other editors.
 
-### Benefits of Autocmds
+### Benefits of autocmds
 
-Autocmds offer a number of advantages over other methods of customization and automation in Neovim.
+Autocmds offer many advantages over other methods of customization and automation in Neovim.
 
 : **Flexibility**
 
-: Autocmds can be used to execute a wide range of commands and actions, making them extremely flexible and customizable.
+: Autocmds can run a wide range of commands and actions, making them extremely flexible and customizable.
 
 : ***Automation**
 
-: Autocmds can be used to automate many repetitive tasks, freeing up the user's time to focus on more important activities.
+: You can use autocmds to automate many repetitive tasks, freeing up your time to focus on more important activities.
 
 : **Integration**
 
-: Autocmds can be used to integrate Neovim with other tools and applications, improving productivity and efficiency.
+: You can use autocmds to integrate Neovim with other tools and applications, improving productivity and efficiency.
 
 ## Autocmds in Rocksmarker
 
@@ -60,39 +60,39 @@ The *commands.lua* file contains several sections covering different aspects of 
 
 : **Autocmd groups**
 
-: Vengono definiti gruppi di autocmd per gestire eventi specifici, come il riavvio dell'editor o la chiusura di una finestra del terminale.
+: Autocmd groups define the handling of specific events, such as restarting the editor or closing a terminal window.
 
 : **File management**
 
-: Rules are defined for restarting files when the editor regains focus or when interactions with the terminal occur.
+: There are rules defined for restarting files when the editor regains focus or when interactions with the terminal occur.
 
 : **Closing specific files**
 
-: Shortcuts are defined to quickly close certain types of files, such as help buffers or notification windows.
+: There are shortcuts defined to quickly close certain types of files, such as help buffers or notification windows.
 
 : **Text highlighting**
 
-: Text highlighting is activated after copying to provide visual feedback to the user.
+: The activation of text highlighting after copying provides visual feedback to the user.
 
 : **Help window management**
 
-: Rules are defined for opening help pages in a vertical window and equalizing window sizes.
+: There are rules defined for opening help pages in a vertical window and equalizing window sizes.
 
 ### RocksmarkerSet group
 
-Creating an autocmd group with a unique name and the ability to empty it offers great flexibility and ease of management for automatic actions in Neovim.
+Creating an autocmd group with a unique name and the ability to empty it, offers great flexibility and ease of management for automatic actions in Neovim.
 
 ```lua
 local augroup = vim.api.nvim_create_augroup("RocksmarkerSet", { clear = true })
 ```
 
-This line of code creates a new autocmd group called **RocksmarkerSet** and empties it if it already exists, so that new autocmds can be added without conflicting with existing ones.  
-The autocmd group is then assigned to the **augroup** variable, which can be used later to add new autocmds to the group.
-This allows you to maintain an organized and easy-to-manage structure for automatic actions within Neovim.
+This line of code creates a new autocmd group called **RocksmarkerSet** and empties it if it already exists, so that adding new autocmds will not conflict with existing ones.  
+The autocmd group is then assigned to the **augroup** variable, which you can use later to add new autocmds to the group.
+This allows for an easily managed and maintained structure for automatic actions within Neovim.
 
 #### Autocmd for restarting files
 
-This autocmd is particularly useful for ensuring that the contents of files opened in Neovim are always up to date, even when external changes are made. This helps prevent situations where the user might be working on an outdated version of a file, reducing the risk of data loss or overwriting changes.
+This autocmd is particularly useful for ensuring that the contents of files opened in Neovim are always up to date, even if you made external changes. This helps prevent situations where the user might be working on an outdated version of a file, reducing the risk of data loss or overwriting changes.
 
 ```lua title="Reload files"
 vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
@@ -106,23 +106,23 @@ vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
 })
 ```
 
-This autocmd is triggered by three different events:
+Triggering this autocmd occurs with three different events:
 
 : `FocusGained`
 
-: When the Neovim editor regains focus after being minimized or covered by another window.
+: When the Neovim editor regains focus after minimization or another window covering it up.
 
 : `TermClose`
 
-: When a terminal window within Neovim is closed.
+: When you close a terminal window within Neovim.
 
 : `TermLeave`
 
 : When the user exits terminal mode within Neovim.
 
-When one of these events occurs, the autocmd executes the defined *callback* function. Within this function, it checks whether the buffer type (**buftype**) is not “**c**,” which indicates a command buffer. If the condition is true, the autocmd executes the **checktime** command.
+When one of these events occurs, the autocmd runs the defined *callback* function. Within this function, it checks whether the buffer type (**buftype**) is not “**c**,” which indicates a command buffer. If the condition is true, the autocmd executes the **checktime** command.
 
-The *checktime* command checks whether the file opened in Neovim has been modified externally (e.g., by another program) and, if so, restarts the file within Neovim to reflect the latest changes.
+The *checktime* command checks if there is any modification by another program to the file opened in Neovim and, if so, restarts the file within Neovim to reflect the latest changes.
 
 #### Quickly close certain file types
 
@@ -150,7 +150,7 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 ```
 
-This autocmd is activated for the following file types:
+This autocmd activates for the following file types:
 
 - PlenaryTestPopup
 - help
@@ -162,15 +162,15 @@ This autocmd is activated for the following file types:
 - checkhealth
 - spectre_panel
 
-When you open a file of one of the types listed above, autocmd executes the defined callback function. Within this function, two operations are performed:
+When you open a file of one of the types listed, the autocmd executes the defined callback function. Within this function it performs two operations:
 
 : `vim.bo[event.buf].buflisted = false`
 
-: This command sets the **buflisted** option of the buffer to *false*, which means that the buffer will not be listed in the list of open buffers in Neovim.
+: This command sets the **buflisted** option of the buffer to *false*, which means that this buffer will not show in the list of open buffers in Neovim.
 
 : `vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })`
 
-: This command defines a key mapping for the current buffer. In normal mode (“n”), pressing the ++“q”++ key will execute the `close` command, which will close the *buffer*. The *silent = true* option ensures that the command is executed without displaying status messages.
+: This command defines a key mapping for the current buffer. In normal mode (“n”), pressing the ++“q”++ key will run the `close` command, which will close the *buffer*. The *silent = true* option ensures that the command runs without displaying status messages.
 
 #### Highlighting text after copying
 
@@ -186,15 +186,15 @@ vim.api.nvim_create_autocmd("TextYankPost", {
 })
 ```
 
-This autocmd is activated when the **TextYankPost** event occurs, which happens after text has been copied to the clipboard.
+This autocmd activates when the **TextYankPost** event occurs, which happens after copying text to the clipboard.
 
-When the *TextYankPost* event occurs, the autocmd executes the defined callback function. Within this function, the `vim.highlight.on_yank()` function is called, which activates the highlighting of the copied text.
+When the *TextYankPost* event occurs, the autocmd runs the defined callback function. Within this function, it calls the `vim.highlight.on_yank()` function, which activates the highlighting of the copied text.
 
-The copied text is highlighted for a short period of time after copying.
+For a short period of time after copying, the copied text remains highlighted.
 
 #### Vertical help buffer
 
-This autocmd allows you to view help pages in a vertical window and equalize the size of the windows. Opening help pages in a vertical window instead of the default horizontal window in Neovim allows you to view help information in a more ergonomic way.
+This autocmd allows for the viewing of help pages in a vertical window and equalizes the size of the windows. Opening help pages in a vertical window, instead of the default horizontal window in Neovim, allows viewing help information in a more ergonomic way.
 
 ```lua title="Vertical help"
 vim.api.nvim_create_autocmd("FileType", {
@@ -209,25 +209,25 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 ```
 
-This autocmd is triggered when you open a file of type **help**, which is the file type used for help pages in Neovim.
+When you open a file of the **help** type, the file type used for help pages in Neovim, it triggers this autocmd.
 
-When a *help* file is opened, the autocmd executes the defined *callback* function. Within this function, three operations are performed:
+When you open a *help* file, the autocmd runs the defined *callback* function. It performs three operations within this function:
 
 : `vim.bo.bufhidden = "unload"`
 
-: This command sets the **bufhidden** option of the buffer to “*unload*,” which means that the buffer will be closed when it is no longer needed.
+: This command sets the **bufhidden** option of the buffer to “*unload*”. This means that the buffer will close when it is no longer needed.
 
 : `vim.cmd.wincmd("L")`
 
-: This command executes the **wincmd** command with the argument “**L**”, which means “go left” and opens the help window to the right of the current window.
+: This command runs the **wincmd** command with the argument “**L**”, which means “go left” and opens the help window to the right of the current window.
 
 : `vim.cmd.wincmd("=")`
 
-: This command executes the **wincmd** command with the argument “**=**”, which means “equalize window sizes” and ensures that windows are the same size.
+: This command runs the **wincmd** command with the argument “**=**”, which means “equalize window sizes” and ensures that windows are the same size.
 
-Vertical help helps you work more efficiently and productively, as you can easily view help information and navigate between windows without having to leave the current window.
+Vertical help allows you work more efficiently and productively, as you can easily view help information and navigate between windows without having to leave the current window.
 
 ## Conclusion
 
-The *commands.lua* file is an important element in customizing the Neovim editing environment. By defining various autocmds, this file allows you to automate repetitive tasks, improve productivity, and simplify your workflow.  
-Each of the features included in the file is designed to improve the user experience and increase productivity, allowing you to work more efficiently and with greater focus.
+The *commands.lua* file is an important element in customizing the Neovim editing environment. By defining various autocmds, this file allows for the automation of repetitive tasks, improving productivity, and simplifying your workflow.  
+The design of each of the features included in the file are there to improve the user experience and increase productivity, allowing you to work more efficiently and with greater focus.


### PR DESCRIPTION
* some sentence simplification
* replace *most* passive voice phrasing with active voice
* appropriate capitalization of Autocmd only when at the beginning of a line (sentence)
* replace some "execute" with "run" as `vale` argues with that term. Run is also simpler language, so it is better to use that in most cases.